### PR TITLE
Reset the line-height to the default. Fixes the alignment of the text in 

### DIFF
--- a/src/main/resources/packages/user/speakeasy/user/user.css
+++ b/src/main/resources/packages/user/speakeasy/user/user.css
@@ -206,6 +206,7 @@ td .plugin-stats {
     min-width: inherit;
 }
 #plugins-table .aui-dropdown li a.item-link {
+    line-height: 16.6px;
     width: inherit;
     min-width: inherit;
 }


### PR DESCRIPTION
Reset the line-height to the default. Fixes the alignment of the text in the 'more' dropdown.
