### PR TITLE
FECRU 2.7 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target
+.idea
 *.iml
 *.ipr
 *.iws

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -506,8 +506,8 @@
         <confluence.data.version>3.0</confluence.data.version>
         <jira.version>4.3.3</jira.version>
         <jira.data.version>4.1.1</jira.data.version>
-        <fecru.version>2.6.0-M2-20110329050339</fecru.version>
-        <fecru.data.version>2.5.2-20110307050326</fecru.data.version>
+        <fecru.version>2.7.0-M3-20110719025103</fecru.version>
+        <fecru.data.version>2.7.0-M3-20110719025103</fecru.data.version>
         <bamboo.version>3.1-m2</bamboo.version>
         <bamboo.data.version>2.6.1</bamboo.data.version>
     </properties>

--- a/plugin/src/main/java/com/atlassian/labs/speakeasy/product/FecruProductAccessor.java
+++ b/plugin/src/main/java/com/atlassian/labs/speakeasy/product/FecruProductAccessor.java
@@ -17,19 +17,20 @@ import java.util.Map;
 
 public class FecruProductAccessor implements ProductAccessor {
 
+    private final Logger log = LoggerFactory.getLogger(FecruProductAccessor.class);
+
     private final PomProperties pomProperties;
     private final UserManager userManager;
-    private final Logger log = LoggerFactory.getLogger(FecruProductAccessor.class);
     private final TemplateRenderer templateRenderer;
     private final RootConfig rootConfig;
 
-    public FecruProductAccessor(PomProperties pomProperties, TemplateRenderer templateRenderer) {
+    public FecruProductAccessor(PomProperties pomProperties, TemplateRenderer templateRenderer, UserManager userManager) {
         this.pomProperties = pomProperties;
         this.templateRenderer = templateRenderer;
 
-        // RootConfig and UserManager arent't exposed to plugins.
+        // RootConfig isn't exposed to plugins.
+        this.userManager = userManager;
         this.rootConfig = AppConfig.getsConfig();
-        this.userManager = rootConfig.getUserManager();
     }
 
     public String getSdkName() {

--- a/plugin/src/main/resources/atlassian-plugin.xml
+++ b/plugin/src/main/resources/atlassian-plugin.xml
@@ -157,6 +157,7 @@
                application="jira"/>
     <component key="productAccessor" class="com.atlassian.labs.speakeasy.product.BambooProductAccessor"
                application="bamboo"/>
+    <component-import key="fecruUserManager" interface="com.cenqua.fisheye.user.UserManager" application="fecru" />
     <component key="productAccessor" class="com.atlassian.labs.speakeasy.product.FecruProductAccessor"
                application="fecru"/>
     <component key="productAccessor" class="com.atlassian.labs.speakeasy.product.RefappProductAccessor"


### PR DESCRIPTION
This is a temporary fix for for speakeasy to work with FECRU 2.7.0-M2 and above.

We are currently adding to our SPI and will most likely change the FecruProductAccessor when we have the right methods so that it should maintain a better backwards compatibility
