### PR TITLE
SPEAKEASY-135: Fixes NPE when plugins are globally enabled and user is not logged in.

### DIFF
--- a/plugin/src/main/java/com/atlassian/labs/speakeasy/descriptor/external/GroupScopedCondition.java
+++ b/plugin/src/main/java/com/atlassian/labs/speakeasy/descriptor/external/GroupScopedCondition.java
@@ -36,6 +36,11 @@ public class GroupScopedCondition implements Condition
     {
         boolean result = false;
         String user = userManager.getRemoteUsername();
+
+        // Fix for SPEAKEASY-135. userManager.isUserInGroup(...) returns NPE if user is null.
+        if (user == null) {
+            return result;
+        }
         for (String group : groups)
         {
             if (userManager.isUserInGroup(user, group))


### PR DESCRIPTION
Hi,

I've fixed one critical error which crashes jira when plugins are globally enabled and users are not logged in (anonymous).
Great if you could pull it to you and release a new version. Thanks!

Best regards,
Michal
